### PR TITLE
Remove dependency for python3-aggdraw and spinner theme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 .PHONY: all main clean install uninstall
 
-x = $(file < /sys/firmware/acpi/bgrt/xoffset)
-y = $(file < /sys/firmware/acpi/bgrt/yoffset)
-
 all: main
 
 main:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ that one shows a progress bar until 50% and the other continues until a smooth t
        
 2. Build images
            
-       sudo apt install python3-aggdraw plymouth-theme-spinner git make
+       sudo apt install python3-pip git make
        cd kde-unified-boot/        
        make
     

--- a/make.py
+++ b/make.py
@@ -1,6 +1,11 @@
-import os
+try:
+    import aggdraw
+except ImportError:
+    from pip._internal import main as pip
+    pip(['install', '--user', 'aggdraw'])
+    import aggdraw
 
-import aggdraw as aggdraw
+import os
 from PIL import Image
 
 size = (256, 8)

--- a/make.py
+++ b/make.py
@@ -46,6 +46,6 @@ if os.path.exists("/sys/firmware/acpi/bgrt/image"):
     im.save("unified-bgrt/image.png")
     im.save("UnifiedSplash/contents/splash/images/image.png")
 else:
-    os.system("cp /usr/share/plymouth/themes/spinner/watermark.png unified-bgrt/image.png")
-    os.system("cp /usr/share/plymouth/themes/spinner/watermark.png UnifiedSplash/contents/splash/images/image.png")
+    os.system("cp /usr/share/plymouth/ubuntu-logo.png unified-bgrt/image.png")
+    os.system("cp /usr/share/plymouth/ubuntu-logo.png UnifiedSplash/contents/splash/images/image.png")
 


### PR DESCRIPTION
This patch is for #1 issue.
It removes dependencies for python3-aggdraw and spinner theme